### PR TITLE
[FEATURE] *breaking* implement schemaInQuery, rename inBody

### DIFF
--- a/__tests__/validation.js
+++ b/__tests__/validation.js
@@ -1,4 +1,10 @@
-const { inQuery, schemaInBody, schemaInQuery, sender, validator } = require("../validation");
+const {
+  inQuery,
+  schemaInBody,
+  schemaInQuery,
+  sender,
+  validator
+} = require("../validation");
 
 describe("validator", () => {
   it("returns a validator with all schemata in a directory", () => {
@@ -119,6 +125,23 @@ describe("schemaInQuery", () => {
     expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalled();
     expect(next).not.toBeCalled();
+  });
+
+  it("accepts missing query parameters if optional is set to true", () => {
+    const ajv = validator(__dirname + "/schema");
+    const middleware = schemaInQuery(ajv, "city.json", "field", true);
+    const req = {
+      query: {}
+    };
+    const res = {
+      send: jest.fn(),
+      status: jest.fn()
+    };
+    const next = jest.fn();
+    middleware(req, res, next);
+    expect(res.status).not.toBeCalled();
+    expect(res.send).not.toBeCalled();
+    expect(next).toBeCalled();
   });
 });
 

--- a/__tests__/validation.js
+++ b/__tests__/validation.js
@@ -1,4 +1,4 @@
-const { validator, inBody, inQuery, sender } = require("../validation");
+const { inQuery, schemaInBody, schemaInQuery, sender, validator } = require("../validation");
 
 describe("validator", () => {
   it("returns a validator with all schemata in a directory", () => {
@@ -10,10 +10,10 @@ describe("validator", () => {
   });
 });
 
-describe("inBody", () => {
+describe("schemaInBody", () => {
   it("accepts a valid body", () => {
     const ajv = validator(__dirname + "/schema");
-    const middleware = inBody(ajv, "city.json");
+    const middleware = schemaInBody(ajv, "city.json");
     const req = {
       body: require("./data/city")
     };
@@ -30,7 +30,7 @@ describe("inBody", () => {
 
   it("rejects a body with missing fields", () => {
     const ajv = validator(__dirname + "/schema");
-    const middleware = inBody(ajv, "city.json");
+    const middleware = schemaInBody(ajv, "city.json");
     const req = {
       body: require("./data/invalidCity")
     };
@@ -47,9 +47,68 @@ describe("inBody", () => {
 
   it("rejects a body with incorrect field types", () => {
     const ajv = validator(__dirname + "/schema");
-    const middleware = inBody(ajv, "city.json");
+    const middleware = schemaInBody(ajv, "city.json");
     const req = {
       body: require("./data/invalidCity1")
+    };
+    const res = {
+      status: jest.fn(),
+      send: jest.fn()
+    };
+    const next = jest.fn();
+    middleware(req, res, next);
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalled();
+    expect(next).not.toBeCalled();
+  });
+});
+
+describe("schemaInQuery", () => {
+  it("accepts a valid query parameter", () => {
+    const ajv = validator(__dirname + "/schema");
+    const middleware = schemaInQuery(ajv, "city.json", "field");
+    const req = {
+      query: {
+        field: JSON.stringify(require("./data/city"))
+      }
+    };
+    const res = {
+      send: jest.fn(),
+      status: jest.fn()
+    };
+    const next = jest.fn();
+    middleware(req, res, next);
+    expect(res.status).not.toBeCalled();
+    expect(res.send).not.toBeCalled();
+    expect(next).toBeCalled();
+  });
+
+  it("rejects a query parameter with missing fields", () => {
+    const ajv = validator(__dirname + "/schema");
+    const middleware = schemaInQuery(ajv, "city.json", "field");
+    const req = {
+      query: {
+        field: JSON.stringify(require("./data/invalidCity"))
+      }
+    };
+    const res = {
+      status: jest.fn(),
+      send: jest.fn()
+    };
+    const next = jest.fn();
+    middleware(req, res, next);
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalled();
+    expect(next).not.toBeCalled();
+  });
+
+  it("rejects a query parameter with incorrect field types", () => {
+    const ajv = validator(__dirname + "/schema");
+    const middleware = schemaInQuery(ajv, "city.json", "field");
+    const req = {
+      query: {
+        field: JSON.stringify(require("./data/invalidCity1"))
+      }
     };
     const res = {
       status: jest.fn(),

--- a/validation.js
+++ b/validation.js
@@ -72,12 +72,20 @@ function schemaInBody(ajv, schema) {
  * gainst the schema for the given name. Aborts the request and sends a status
  * code of 400 and validation errors, if the validation fails.
  *
- * @param {*} ajv Validator object as returned from `validator` above.
- * @param {String} schema Name of a schema that must be present in the validator.
- * @param {String} fieldName The name of the query parameter to validate.
+ * @param {*} ajv             Validator object as returned from `validator` a-
+ *                            bove.
+ * @param {String}  schema    Name of a schema that must be present in the vali-
+ *                            dator.
+ * @param {String}  fieldName The name of the query parameter to validate.
+ * @param {Boolean} optional  Whether a missing query parameter should be accep-
+ *                            ted as valid.
  */
-function schemaInQuery(ajv, schema, fieldName) {
+function schemaInQuery(ajv, schema, fieldName, optional = false) {
   return (req, res, next) => {
+    if (optional && req.query[fieldName] === undefined) {
+      return next();
+    }
+
     const value = JSON.parse(req.query[fieldName]);
 
     if (!ajv.validate(schema, value)) {

--- a/validation.js
+++ b/validation.js
@@ -7,7 +7,7 @@ const { isNil, map, pipe, filter, propEq, prop, isEmpty } = require("ramda");
 /**
  * Returns a validator with all schemata from the given directory
  *
- * @param {string} dir An path to a directory containing json schema files.
+ * @param {string} dir A path to a directory containing json schema files.
  * @param {*} metaschema A path to a metaschema to use.
  */
 function validator(dir, metaschema = "ajv/lib/refs/json-schema-draft-04.json") {
@@ -22,28 +22,6 @@ function validator(dir, metaschema = "ajv/lib/refs/json-schema-draft-04.json") {
     }
   }
   return ajv;
-}
-
-/**
- * Returns a middleware that validates the requests body against the schema for
- * the given name. Aborts the request and sends a status code of 400 and valida-
- * tion errors, if the validation fails.
- *
- * @param {*} ajv Validator object as returned from `validator` above.
- * @param {String} schema Name of a schema that must be present in the validator.
- */
-function inBody(ajv, schema) {
-  return (req, res, next) => {
-    if (!ajv.validate(schema, req.body)) {
-      res.status(400);
-      responseData = {
-        validationErrors: ajv.errors
-      };
-      res.send(responseData);
-      return;
-    }
-    next();
-  };
 }
 
 /**
@@ -64,6 +42,53 @@ function sender(ajv, schema) {
       res.status(status);
       res.send(body);
     }
+  };
+}
+
+/**
+ * Returns a middleware that validates the requests body against the schema for
+ * the given name. Aborts the request and sends a status code of 400 and valida-
+ * tion errors, if the validation fails.
+ *
+ * @param {*} ajv Validator object as returned from `validator` above.
+ * @param {String} schema Name of a schema that must be present in the validator.
+ */
+function schemaInBody(ajv, schema) {
+  return (req, res, next) => {
+    if (!ajv.validate(schema, req.body)) {
+      res.status(400);
+      responseData = {
+        validationErrors: ajv.errors
+      };
+      res.send(responseData);
+      return;
+    }
+    next();
+  };
+}
+
+/**
+ * Returns a middleware that validates one of the requests query parameters a-
+ * gainst the schema for the given name. Aborts the request and sends a status
+ * code of 400 and validation errors, if the validation fails.
+ *
+ * @param {*} ajv Validator object as returned from `validator` above.
+ * @param {String} schema Name of a schema that must be present in the validator.
+ * @param {String} fieldName The name of the query parameter to validate.
+ */
+function schemaInQuery(ajv, schema, fieldName) {
+  return (req, res, next) => {
+    const value = JSON.parse(req.query[fieldName]);
+
+    if (!ajv.validate(schema, value)) {
+      res.status(400);
+      responseData = {
+        validationErrors: ajv.errors
+      };
+      res.send(responseData);
+      return;
+    }
+    next();
   };
 }
 
@@ -114,8 +139,9 @@ function inQuery(...params) {
 }
 
 module.exports = {
-  validator,
-  inBody,
+  inQuery,
   sender,
-  inQuery
+  schemaInBody,
+  schemaInQuery,
+  validator
 };


### PR DESCRIPTION
Hi :>

I went ahead and implemented the `schemaInQuery` variant I needed. I also renamed `inBody` to `schemaInBody` for consistence (and updated all the tests of course).
Since one of the exports changes, this is a breaking change and warrants a major release.

yeldiR